### PR TITLE
Fix bootc runtime not working during install

### DIFF
--- a/disk_config/iso.toml
+++ b/disk_config/iso.toml
@@ -13,7 +13,8 @@ enable = [
   "org.fedoraproject.Anaconda.Modules.Security",
   "org.fedoraproject.Anaconda.Modules.Services",
   "org.fedoraproject.Anaconda.Modules.Users",
-  "org.fedoraproject.Anaconda.Modules.Timezone"
+  "org.fedoraproject.Anaconda.Modules.Timezone",
+  "org.fedoraproject.Anaconda.Modules.Runtime"
 ]
 disable = [
   "org.fedoraproject.Anaconda.Modules.Subscription"


### PR DESCRIPTION
Fixes https://github.com/osbuild/bootc-image-builder/issues/968#issuecomment-3086099219